### PR TITLE
Add support for Super Mario Maker 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Super Mario Maker Idea Generator
 
-This webapp generates level creation ideas for Super Mario Maker.
+This webapp generates level creation ideas for Super Mario Maker or Super Mario Maker 2.
 To use it go to [zeknir.github.io/SMM-IdeaGenerator](http://zeknir.github.io/SMM-IdeaGenerator)

--- a/index.html
+++ b/index.html
@@ -11,6 +11,13 @@
 <body onload="generate()">
     <div class="main">
         <h1>Super Mario Maker Idea Generator</h1>
+        <p class= "gameSelection">What game are you playing ?</p>
+        <div class="selectContainer">
+            <select id="gameSelector" onchange="toggleGame()">
+                 <option value="SMM1">Super Mario Maker</option>
+                 <option value="SMM2">Super Mario Maker 2</option>
+            </select>
+        </div>
         <p class="intro">How about:</p>
 
         <div class="idea">

--- a/scripts.js
+++ b/scripts.js
@@ -25,7 +25,7 @@ var smm2OnlyObjects = ["10-Coins", "30-Coins", "50-Coins", "Dry Bones Shells", "
 var smm2OnlyMechanics = ["ON-OFF Switches", "Snake Blocks", "Fast Snake Blocks"]
 var sm3wObjects = ["Blocks", "Bullet Bills", "Fireflowers", "Stars", "Super Bells", "Super Hammer", "Mushrooms", "Coins", "Springboards", "Goombas", "Koopas", "Ant Troopers", "Horned Ant Troopers", "Spinys", "Bloopers", "Cheep Cheeps",
 "Skipsqueaks", "Spiny Skipsqueak", "Stingby", "Piranha Plants", "Fire Piranha Plants", "Piranha Creepers", "Thwomps", "Hammer Bros", "Fire Bros", "Hop Chops", "Boos",
-"Peepas", "Lava Bubbles", "Bob-ombs", "Dry Bones", "Fish Bones", "Magikoopas", "Meowser", "Boom Booms", "Pom Poms", "Charvaarghs", "Bullys", "Porcupffers", "Koopa Car", "Bill Blasters", "Banzai Bills", "Icicle", "Twisters", 
+"Peepas", "Podoboos", "Bob-ombs", "Dry Bones", "Fish Bones", "Kameks", "Meowser", "Boom Booms", "Pom Poms", "Charvaarghs", "Bullys", "Porcupffers", "Koopa Car", "Bill Blasters", "Banzai Bills", "Icicle", "Twisters",
 "POW-Blocks", "P Switches", "Cloud Lifts", "! Blocks"];
 var sm3wMechanics = ["ON-OFF Switches", "Snake Blocks", "Fast Snake Blocks", "Pipes", "Clear Pipes", "Spike Blocks", "Doors", "Trees", "Conveyors Belts", "Track Blocks", "Blinking Blocks", "Mushroom Trampolines", "Warp Boxes"];
 var smm2smbOnlyObjects = ["Superball Flowers"];
@@ -58,9 +58,12 @@ function toggleType() {
 }
 
 function generate() {
-    if (game == "SMM2") {
+    if (game === "SMM2") {
         allStyles = style.concat(smm2OnlyStyles);
         allEnvironments = environents.concat(smm2OnlyEnvironments);
+    } else {
+        allStyles = style;
+        allEnvironments = environents;
     }
     var outputStyleElement = document.getElementById("ideaStyle");
     var styleId = getRandom(0, allStyles.length - 1);

--- a/scripts.js
+++ b/scripts.js
@@ -72,7 +72,7 @@ function generate() {
 
     var outputTypeElement = document.getElementById("ideaType");
     if (document.getElementById("checkboxType").checked === true) {
-        outputTypeElement.innerHTML = getEnvironment();
+        outputTypeElement.innerHTML = getEnvironment(styleId);
     } else {
         outputTypeElement.parentElement.className = "ideaDis";
     }
@@ -121,9 +121,9 @@ function getStyle(styleId) {
     return output;
 }
 
-function getEnvironment() {
+function getEnvironment(styleId) {
     var output = "";
-    if (game === "SMM2") {
+    if ((game === "SMM2") && (styleId !== 4)){
         if (getRandom(1, 2) === 1) {
             output = output.concat("Day ");
         } else {

--- a/scripts.js
+++ b/scripts.js
@@ -1,7 +1,7 @@
 ﻿var style = ["Super Mario Bros", "Super Mario Bros 3", "Super Mario World", "New Super Mario Bros U"];
 var environents = ["Overworld", "Underground", "Water", "Ghost House", "Airship", "Castle"];
 
-var objects = ["Blocks", "Mushrooms", "Coins", "Springboards", "Goombas", "Koopas", "Piranha Plants", "Lakitus", "Clouds", "Spinys", "Moving platforms",
+var objects = ["Blocks", "P Switches", "Mushrooms", "Coins", "Springboards", "Goombas", "Koopas", "Piranha Plants", "Lakitus", "Clouds", "Spinys", "Moving platforms",
                "Fireflowers", "Stars", "Bullet Bills", "Bill Blasters", "Bloopers", "Cheep-cheep", "Hammer Bros", "Buzzy Beetles", "Thwomps", "Podoboos", "Bowser", "Bowser Jr.",
                "Noteblocks", "Musicblocks", "Skull platforms", "Firebars", "Rocky Wrenches", "Monty Moles", "Bob-ombs", "Donut Blocks", "POW-Blocks", "Firethrowers", "Cannons", "Spike Tops", "Boos", "Dry Bones",
                "Kameks", "Hidden blocks", "Munchers", "Wigglers", "Clowncars", "Chain Chomps", "Spiny helmet", "Beetle helmet"];
@@ -9,7 +9,7 @@ var nsmbuOnlyObjects = ["Propeller Mushrooms"];
 var smwOnlyObjects = ["Feathers"];
 var smb3OnlyObjects = ["Tanookis"];
 var smbOnlyObjects = [];
-
+var game = "SMM1";
 var mechanics = ["Pipes", "Platforms", "Vines", "Doors", "Spikes", "Rails", "Conveyor belts", "Sawblades", "Ice blocks",
                 "Oneway blocks"];
 var nsmbuOnlyMechanics = ["Wall-jumping", "Ground-pounding", "Spin-jumping", "Yoshis"];
@@ -19,6 +19,18 @@ var smbOnlyMechanics = ["Costumes", "Kuribo's Shoe"];
 
 var additionalMechanics = ["Scrolling", "Fast scrolling", "Slow scrolling", "Short time", "Sound effects", "Mazes", "Puzzles"];
 
+var smm2OnlyStyles = ["Super Mario 3D World"];
+var smm2OnlyEnvironments = ["Desert", "Snow", "Forest", "Sky"]
+var smm2OnlyObjects = ["10-Coins", "30-Coins", "50-Coins", "Dry Bones Shells", "Boom Booms", "Banzai Bills", "Icicles", "Twisters", "Angry Sun"]
+var smm2OnlyMechanics = ["ON-OFF Switches", "Snake Blocks", "Fast Snake Blocks"]
+var sm3wObjects = ["Blocks", "Bullet Bills", "Fireflowers", "Stars", "Super Bells", "Super Hammer", "Mushrooms", "Coins", "Springboards", "Goombas", "Koopas", "Ant Troopers", "Horned Ant Troopers", "Spinys", "Bloopers", "Cheep Cheeps",
+"Skipsqueaks", "Spiny Skipsqueak", "Stingby", "Piranha Plants", "Fire Piranha Plants", "Piranha Creepers", "Thwomps", "Hammer Bros", "Fire Bros", "Hop Chops", "Boos",
+"Peepas", "Lava Bubbles", "Bob-ombs", "Dry Bones", "Fish Bones", "Magikoopas", "Meowser", "Boom Booms", "Pom Poms", "Charvaarghs", "Bullys", "Porcupffers", "Koopa Car", "Bill Blasters", "Banzai Bills", "Icicle", "Twisters", 
+"POW-Blocks", "P Switches", "Cloud Lifts", "! Blocks"];
+var sm3wMechanics = ["ON-OFF Switches", "Snake Blocks", "Fast Snake Blocks", "Pipes", "Clear Pipes", "Spike Blocks", "Doors", "Trees", "Conveyors Belts", "Track Blocks", "Blinking Blocks", "Mushroom Trampolines", "Warp Boxes"];
+var smm2smbOnlyObjects = ["Superball Flowers"];
+var allStyles = style;
+var allEnvironments = environents;
 function toggleStyle() {
     var styleElement = document.getElementById("ideaStyle").parentElement;
     var input = document.getElementById("checkboxStyle");
@@ -27,6 +39,12 @@ function toggleStyle() {
     } else {
         styleElement.className = "ideaDis";
     }
+}
+
+function toggleGame() {
+    var input=document.getElementById("gameSelector");
+    game = input.options[input.selectedIndex].value;
+    generate();
 }
 
 function toggleType() {
@@ -40,8 +58,12 @@ function toggleType() {
 }
 
 function generate() {
+    if (game == "SMM2") {
+        allStyles = style.concat(smm2OnlyStyles);
+        allEnvironments = environents.concat(smm2OnlyEnvironments);
+    }
     var outputStyleElement = document.getElementById("ideaStyle");
-    var styleId = getRandom(0, style.length - 1);
+    var styleId = getRandom(0, allStyles.length - 1);
     if (document.getElementById("checkboxStyle").checked === true) {
         outputStyleElement.innerHTML = getStyle(styleId);
     } else {
@@ -94,38 +116,63 @@ function generate() {
 
 function getStyle(styleId) {
     var output = "";
-    output = output.concat(style[styleId]);
+    output = output.concat(allStyles[styleId]);
     output = output.concat(" style");
     return output;
 }
 
 function getEnvironment() {
     var output = "";
-    output = output.concat(environents[getRandom(0, environents.length - 1)]);
+    if (game === "SMM2") {
+        if (getRandom(1, 2) === 1) {
+            output = output.concat("Day ");
+        } else {
+            output = output.concat("Night ");
+        }
+    }
+    output = output.concat(allEnvironments[getRandom(0, allEnvironments.length - 1)]);
     output = output.concat(" level");
     return output;
 }
 
 function getObject(styleId) {
     var output = "";
-
-    if (styleId === 0) {
-        allObjects = objects.concat(smbOnlyObjects);
+    var allObjects;
+    if (game === "SMM2") {
+        allObjects = objects.concat(smm2OnlyObjects);
+        if (styleId === 0) {
+            allObjects = objects.concat(smbOnlyObjects).concat(smm2smbOnlyObjects);
+        }
+        else if (styleId === 1) {
+            allObjects = objects.concat(smb3OnlyObjects);
+        }
+        else if (styleId === 2) {
+            allObjects = objects.concat(smwOnlyObjects);
+        }
+        else if (styleId === 3) {
+            allObjects = objects.concat(nsmbuOnlyObjects);
+        } 
+        else if (styleId === 4) {
+            allObjects = sm3wObjects;
+        }
+    } else {
+        if (styleId === 0) {
+            allObjects = objects.concat(smbOnlyObjects);
+        }
+        else if (styleId === 1) {
+            allObjects = objects.concat(smb3OnlyObjects);
+        }
+        else if (styleId === 2) {
+            allObjects = objects.concat(smwOnlyObjects);
+        }
+        else if (styleId === 3) {
+            allObjects = objects.concat(nsmbuOnlyObjects);
+        }
     }
-    else if (styleId === 1) {
-        allObjects = objects.concat(smb3OnlyObjects);
-    }
-    else if (styleId === 2) {
-        allObjects = objects.concat(smwOnlyObjects);
-    }
-    else if (styleId === 3) {
-        allObjects = objects.concat(nsmbuOnlyObjects);
-    }
-
     output = output.concat(allObjects[getRandom(0, allObjects.length - 1)]);
 
     if (getRandom(1, 2) === 1) {
-        if (getRandom(1, 3) === 1) {
+        if ((styleId !== 4) && (getRandom(1, 3) === 1)) {
             output = output.concat(" on rails ");
         } else {
             output = " flying ".concat(output);
@@ -139,22 +186,43 @@ function getMechanic(styleId) {
     var output = "";
     var allMechanics;
 
-    if (styleId === 0) {
-        allMechanics = mechanics.concat(smbOnlyMechanics);
+    if (game === "SMM2") {
+        allMechanics = mechanics.concat(smm2OnlyMechanics);
+        if (styleId === 0) {
+            allMechanics = mechanics.concat(smbOnlyMechanics);
+        }
+        else if (styleId === 1) {
+            allMechanics = mechanics.concat(smb3OnlyMechanics);
+        }
+        else if (styleId === 2) {
+            allMechanics = mechanics.concat(smwOnlyMechanics);
+        }
+        else if (styleId === 3) {
+            allMechanics = mechanics.concat(nsmbuOnlyMechanics);
+        }
+        else if (styleId === 4) {
+            allMechanics = sm3wMechanics;
+        }
+        else {
+            allMechanics = mechanics;
+        }
+    } else {
+        if (styleId === 0) {
+            allMechanics = mechanics.concat(smbOnlyMechanics);
+        }
+        else if (styleId === 1) {
+            allMechanics = mechanics.concat(smb3OnlyMechanics);
+        }
+        else if (styleId === 2) {
+            allMechanics = mechanics.concat(smwOnlyMechanics);
+        }
+        else if (styleId === 3) {
+            allMechanics = mechanics.concat(nsmbuOnlyMechanics);
+        }
+        else {
+            allMechanics = mechanics;
+        }
     }
-    else if (styleId === 1) {
-        allMechanics = mechanics.concat(smb3OnlyMechanics);
-    }
-    else if (styleId === 2) {
-        allMechanics = mechanics.concat(smwOnlyMechanics);
-    }
-    else if (styleId === 3) {
-        allMechanics = mechanics.concat(nsmbuOnlyMechanics);
-    }
-    else {
-        allMechanics = mechanics;
-    }
-
     output = allMechanics[getRandom(0, allMechanics.length - 1)];
     return output;
 }

--- a/style.css
+++ b/style.css
@@ -37,6 +37,19 @@ div.buttonContainer {
     text-align: center;
 }
 
+div.selectContainer {
+    text-align: center;
+    background-color: #FFFFFF;
+    border: 1px solid #CCCCCC;
+    border-radius: 10px;
+    margin: 30px 5%;
+    display: block;
+}
+
+select {
+    font: 30px "Arial";
+    font-weight: bold;
+}
 .checkbox-custom {
     opacity: 0;
     position: absolute;
@@ -139,6 +152,9 @@ p {
     p.footer {
         margin-top: 50px;
         color: #555555;
+    }
+    p.gameSelection {
+        font-size: 30px;
     }
 
 h1 {

--- a/style.css
+++ b/style.css
@@ -39,17 +39,20 @@ div.buttonContainer {
 
 div.selectContainer {
     text-align: center;
-    background-color: #FFFFFF;
-    border: 1px solid #CCCCCC;
-    border-radius: 10px;
-    margin: 30px 5%;
     display: block;
 }
 
 select {
     font: 30px "Arial";
     font-weight: bold;
+    text-align: center;
+    border-radius: 10px;
+    background-color: #ff9233;
+    border: #777 1px solid;
+    box-shadow: 1px 1px 3px 1px #000000;
+
 }
+
 .checkbox-custom {
     opacity: 0;
     position: absolute;


### PR DESCRIPTION
I added a select at the top to select which game to generate combinations for (Super Mario Maker 1 or 2) and all new objects, style and environments for SMM2, and adapted the functions to select these new objects. You can test this new version at (https://batro.github.io/SMM-IdeaGenerator/)